### PR TITLE
Fix: Prevent double playback of move sound

### DIFF
--- a/app/src/main/java/com/a_gud_boy/tictactoe/InfiniteTicTacToe.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/InfiniteTicTacToe.kt
@@ -343,7 +343,7 @@ fun InfiniteTicTacToePage(
                         buttonId = buttonId, // Pass buttonId for accessibility
                         onClick = {
                             view.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                            soundManager.playMoveSound()
+                            // soundManager.playMoveSound()
                             viewModel.onButtonClick(buttonId)
                         }
                     )

--- a/app/src/main/java/com/a_gud_boy/tictactoe/NormalTicTacToe.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/NormalTicTacToe.kt
@@ -311,7 +311,7 @@ fun NormalTicTacToePage(
                             // TODO: Check if move is valid before playing sound,
                             // or play sound optimistically and handle invalid move UI separately.
                             // For now, play sound before ViewModel action.
-                            soundManager.playMoveSound()
+                            // soundManager.playMoveSound()
                             viewModel.onButtonClick(buttonId)
                         }
                     )


### PR DESCRIPTION
The move sound was being played twice for human player moves: once in the UI layer (TicTacToeCell composable in NormalTicTacToe.kt and InfiniteTicTacToe.kt) and again in the respective ViewModel (NormalTicTacToeViewModel.kt and InfiniteTicTacToeViewModel.kt) upon processing the button click.

This commit removes the `soundManager.playMoveSound()` call from the `onClick` handler in both `NormalTicTacToe.kt` and `InfiniteTicTacToe.kt`. The ViewModels are already correctly handling the sound playback after validating and processing the move.

This ensures the move sound is played only once per human player action. AI move sounds and other game sounds (win, lose, draw) were unaffected and remain as intended.