### PR TITLE
Refactor: Display correct opponent type in match history

### DIFF
--- a/app/src/main/java/com/a_gud_boy/tictactoe/AppDatabase.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/AppDatabase.kt
@@ -13,7 +13,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [MatchEntity::class, RoundEntity::class, MoveEntity::class],
-    version = 2, // Incremented version
+    version = 3, // Incremented version
     exportSchema = false // Recommended to set to true for production apps for schema history
 )
 @TypeConverters(MatchWinnerTypeConverter::class) // Add the new type converter
@@ -35,7 +35,7 @@ abstract class AppDatabase : RoomDatabase() {
                     "tictactoe_history_database" // Database file name
                 )
                     // Removed fallbackToDestructiveMigration to use explicit migration
-                    .addMigrations(MIGRATION_1_2) // Add the migration
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3) // Add the new migration
                     .build()
                 INSTANCE = instance
                 instance
@@ -56,6 +56,13 @@ abstract class AppDatabase : RoomDatabase() {
                 database.execSQL("UPDATE matches SET winner = '${MatchWinner.PLAYER2.name}' WHERE player2Score > player1Score")
 
                 // Rows where player1Score == player2Score will correctly remain as DRAW due to the default.
+            }
+        }
+
+        // Migration from version 2 to 3: Adds the 'isAgainstAi' column to 'matches'
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE matches ADD COLUMN isAgainstAi INTEGER NOT NULL DEFAULT 0")
             }
         }
     }

--- a/app/src/main/java/com/a_gud_boy/tictactoe/HistoryPage.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/HistoryPage.kt
@@ -202,6 +202,7 @@ fun MatchHistoryItem(
     onDeleteClicked: () -> Unit // New parameter
 ) {
     val match = matchWithRoundsAndMoves.match
+    val opponentName = if (match.isAgainstAi) "AI" else "Player 2" // Added opponentName
     // Updated date formatter for 12-hour format with AM/PM
     val dateFormatter = remember { SimpleDateFormat("MMM dd, yyyy - hh:mm a", Locale.getDefault()) }
 
@@ -274,7 +275,7 @@ fun MatchHistoryItem(
                     style = MaterialTheme.typography.bodySmall
                 )
                 Text(
-                    text = "You: ${match.player1Score} – AI: ${match.player2Score}", // Updated score label
+                    text = "You: ${match.player1Score} – $opponentName: ${match.player2Score}", // Updated score label
                     style = MaterialTheme.typography.bodySmall
                 )
 

--- a/app/src/main/java/com/a_gud_boy/tictactoe/InfiniteTicTacToeViewModel.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/InfiniteTicTacToeViewModel.kt
@@ -221,6 +221,7 @@ class InfiniteTicTacToeViewModel(
                 player2Score = p2FinalScore,
                 matchWinnerName = matchWinnerName,
                 winner = winner, // Pass the determined winner
+                isAgainstAi = _isAIMode.value, // <<< THIS LINE IS ADDED/MODIFIED
                 timestamp = System.currentTimeMillis()
             )
             val matchId = matchDao.insertMatch(matchEntity)

--- a/app/src/main/java/com/a_gud_boy/tictactoe/MatchEntity.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/MatchEntity.kt
@@ -21,6 +21,7 @@ data class MatchEntity(
     val player2Score: Int,
     val matchWinnerName: String, // e.g., "You Won 2-1", "AI Won 3-0"
     val winner: MatchWinner, // New field for the actual winner
+    val isAgainstAi: Boolean = false, // New field
     val timestamp: Long = System.currentTimeMillis() // Store as Long
 )
 

--- a/app/src/main/java/com/a_gud_boy/tictactoe/NormalTicTacToeViewModel.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/NormalTicTacToeViewModel.kt
@@ -216,6 +216,7 @@ class NormalTicTacToeViewModel(
                 player2Score = p2FinalScore,
                 matchWinnerName = matchWinnerName,
                 winner = winner, // Pass the determined winner
+                isAgainstAi = _isAIMode.value, // <<< THIS LINE IS ADDED/MODIFIED
                 timestamp = System.currentTimeMillis()
             )
 


### PR DESCRIPTION
This commit updates the match history to accurately display the opponent as either "AI" or "Player 2".

Changes include:
- Added an `isAgainstAi` boolean field to the `MatchEntity` to store the opponent type for each match.
- Updated the Room database schema (version 2 to 3) and provided a migration to add the new `isAgainstAi` column to the `matches` table, defaulting to `false` for existing entries.
- Modified `NormalTicTacToeViewModel` and `InfiniteTicTacToeViewModel` to populate the `isAgainstAi` field when a match is saved, based on the current AI mode setting.
- Updated the `MatchHistoryItem` composable in `HistoryPage.kt` to conditionally display the opponent's name ("AI" or "Player 2") based on the `isAgainstAi` field.