### PR TITLE
Fix: Update Round Replay UI

### DIFF
--- a/app/src/main/java/com/a_gud_boy/tictactoe/MainPage.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/MainPage.kt
@@ -206,10 +206,11 @@ fun MainPage() { // Removed viewModelFactory parameter
                             2 -> {
                                 val navBackStackEntry by navController.currentBackStackEntryAsState()
                                 val currentRoute = navBackStackEntry?.destination?.route
-                                if (currentRoute?.startsWith("match_details/") == true) {
+                                if (currentRoute?.startsWith("roundReplay/") == true) {
+                                    "Match Replay"
+                                } else if (currentRoute?.startsWith("match_details/") == true) {
                                     "Match Details"
                                 } else {
-                                    // Reverted title for history_list
                                     "History"
                                 }
                             }

--- a/app/src/main/java/com/a_gud_boy/tictactoe/RoundReplayScreen.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/RoundReplayScreen.kt
@@ -126,10 +126,6 @@ fun RoundReplayScreen(
             focusRequester.requestFocus()
         }
 
-        Text(
-            text = "Replaying Match ID: $matchId, Round ID: $roundId",
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
         val totalMoves = moves.size
         val displayMoveIndex = if (currentMoveIndex == -1) 0 else currentMoveIndex + 1
         Text(


### PR DESCRIPTION
- Removed Match ID and Round ID text from the Round Replay screen.
- Changed the TopAppBar title to "Match Replay" when the Round Replay screen is active.

These changes address the issue of simplifying the Round Replay interface and providing a more accurate context in the app bar.