### PR TITLE
Refactor SoundManager and add DB index for timestamp

### DIFF
--- a/app/src/main/java/com/a_gud_boy/tictactoe/InfiniteTicTacToe.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/InfiniteTicTacToe.kt
@@ -115,16 +115,6 @@ fun InfiniteTicTacToePage(
     // Stores the layout coordinates of each cell button. Used for drawing the winning line.
     val buttonCoordinates = remember { mutableStateMapOf<String, LayoutCoordinates>() }
 
-    val context = LocalContext.current
-    // SoundManager instance for playing game sounds.
-    val soundManager = remember { SoundManager(context) }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            soundManager.release()
-        }
-    }
-
     val view = LocalView.current
     // Animatable progress for drawing the winning line (0f to 1f).
     val lineAnimationProgress = remember { Animatable(0f) }
@@ -139,12 +129,6 @@ fun InfiniteTicTacToePage(
         if (winnerInfo != null) {
             // Provide haptic feedback for game conclusion.
             HapticFeedbackManager.performHapticFeedback(view, HapticFeedbackConstants.CONFIRM)
-            // Play win or draw sound based on whether there's a specific winner or it's a draw.
-            if (winnerInfo?.winner != null) {
-                soundManager.playWinSound(volume)
-            } else { // Draw condition
-                soundManager.playDrawSound(volume)
-            }
             // Store the sequence of button IDs that form the winning line.
             orderedWinningCombination.value = winnerInfo!!.orderedWin
 

--- a/app/src/main/java/com/a_gud_boy/tictactoe/MatchEntity.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/MatchEntity.kt
@@ -3,6 +3,7 @@ package com.a_gud_boy.tictactoe
 
 import androidx.room.Embedded
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.Relation
 import java.util.Date // Import for Timestamp
@@ -13,7 +14,7 @@ enum class MatchWinner {
     DRAW
 }
 
-@Entity(tableName = "matches")
+@Entity(tableName = "matches", indices = [Index(value = ["timestamp"])])
 data class MatchEntity(
     @PrimaryKey(autoGenerate = true) val matchId: Long = 0,
     val matchNumber: Int, // Could be a sequence or based on count

--- a/app/src/main/java/com/a_gud_boy/tictactoe/NormalTicTacToe.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/NormalTicTacToe.kt
@@ -108,29 +108,14 @@ fun NormalTicTacToePage(
     // Holds the button IDs of the winning combination in order, to correctly draw/animate the line.
     val orderedWinningCombination = remember { mutableStateOf<List<String>>(emptyList()) }
 
-    val context = LocalContext.current
-    val soundManager = remember { SoundManager(context) }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            soundManager.release()
-        }
-    }
-
     val view = LocalView.current
     // This LaunchedEffect observes changes in winnerInfo.
-    // When a game concludes (win or draw), it triggers haptic feedback, plays a sound,
+    // When a game concludes (win or draw), it triggers haptic feedback,
     // sets up the winning line coordinates, and starts the line drawing animation.
     LaunchedEffect(winnerInfo) {
         if (winnerInfo != null) {
             // Provide haptic feedback for game conclusion.
             HapticFeedbackManager.performHapticFeedback(view, HapticFeedbackConstants.CONFIRM)
-            // Play win or draw sound.
-            if (winnerInfo?.winner != null) {
-                soundManager.playWinSound(volume)
-            } else { // Draw condition
-                soundManager.playDrawSound(volume)
-            }
             // Store the winning move combination to draw the line.
             orderedWinningCombination.value = winnerInfo!!.orderedWinningMoves
 


### PR DESCRIPTION
This commit implements two key optimizations:

1.  **Refactor SoundManager Usage:**
    - Removed redundant local `SoundManager` instances from `NormalTicTacToePage.kt` and `InfiniteTicTacToePage.kt`.
    - Sound playback for game events (moves, win, lose, draw) is now exclusively handled by the `SoundManager` instance injected into your respective ViewModels (`NormalTicTacToeViewModel`, `InfiniteTicTacToeViewModel`).
    - This change centralizes sound logic, reduces resource duplication (multiple SoundPools and loaded sounds), and improves memory management.

2.  **Add Database Index to MatchEntity:**
    - Added an index to the `timestamp` column in the `MatchEntity`.
    - This improves database query performance when fetching and sorting your match history, especially as the number of recorded matches grows.
    - The `@Entity` annotation in `MatchEntity.kt` has been updated to include `indices = [Index(value = ["timestamp"])]`.

These changes contribute to better resource management and database efficiency, enhancing overall app performance and stability.