### PR TITLE
feat: Add 'Save History' setting

### DIFF
--- a/app/src/main/java/com/a_gud_boy/tictactoe/AISettingsManager.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/AISettingsManager.kt
@@ -11,6 +11,7 @@ object AISettingsManager {
     private const val KEY_DIFFICULTY = "key_difficulty"
     private const val KEY_AI_MODE = "key_ai_mode"
     private const val KEY_SOUND_ENABLED = "key_sound_enabled"
+    private const val KEY_SAVE_HISTORY = "key_save_history"
 
     private var sharedPreferences: SharedPreferences? = null
 
@@ -32,11 +33,19 @@ object AISettingsManager {
         }
 
     private var _isSoundEnabled by mutableStateOf(true)
+    private var _saveHistoryEnabled by mutableStateOf(true) // Default to true
     var isSoundEnabled: Boolean
         get() = _isSoundEnabled
         set(value) {
             _isSoundEnabled = value
             sharedPreferences?.edit()?.putBoolean(KEY_SOUND_ENABLED, value)?.apply()
+        }
+
+    var saveHistoryEnabled: Boolean
+        get() = _saveHistoryEnabled
+        set(value) {
+            _saveHistoryEnabled = value
+            sharedPreferences?.edit()?.putBoolean(KEY_SAVE_HISTORY, value)?.apply()
         }
 
     fun init(context: Context) {
@@ -63,6 +72,8 @@ object AISettingsManager {
 
             // Load sound enabled
             _isSoundEnabled = prefs.getBoolean(KEY_SOUND_ENABLED, true)
+            // Load save history enabled
+            _saveHistoryEnabled = prefs.getBoolean(KEY_SAVE_HISTORY, true) // Default to true
         }
     }
 }

--- a/app/src/main/java/com/a_gud_boy/tictactoe/HistoryViewModelFactory.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/HistoryViewModelFactory.kt
@@ -1,0 +1,14 @@
+package com.a_gud_boy.tictactoe
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class HistoryViewModelFactory(private val matchDao: MatchDao) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(HistoryViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return HistoryViewModel(matchDao) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/java/com/a_gud_boy/tictactoe/InfiniteTicTacToeViewModel.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/InfiniteTicTacToeViewModel.kt
@@ -252,30 +252,36 @@ class InfiniteTicTacToeViewModel(
                 timestamp = System.currentTimeMillis(),
                 duration = gameTimer.getFinalMatchDuration()
             )
-            val matchId = matchDao.insertMatch(matchEntity)
 
-            // Save all accumulated rounds. Their winningCombinationJson should be set
-            // either by previous calls to resetRound() or by the logic at the start of this function.
-            _currentMatchRounds.value.forEach { roundWithMoves ->
-                val actualRoundEntity = roundWithMoves.round.copy(ownerMatchId = matchId)
-                // roundDao.insertRound(actualRoundEntity) // roundWithMoves.round already has winningCombinationJson
-                // val roundId = actualRoundEntity.roundId // Assuming insertRound returns the ID or it's auto-generated and part of actualRoundEntity
+            if (AISettingsManager.saveHistoryEnabled) {
+                val matchId = matchDao.insertMatch(matchEntity)
 
-                // If roundId is not directly available, this part might need adjustment
-                // For now, assume roundId is obtainable for linking moves.
-                // A more robust way would be to get the returned roundId from insertRound.
-                // However, RoundEntity's PK is autoGenerate=true. The DAO insert should return the generated ID.
-                // For simplicity, we'll assume the roundId from actualRoundEntity is sufficient if it's auto-updated post-insert,
-                // or that the DAO structure handles this. The critical part is that actualRoundEntity has the JSON string.
-                // The subtask should ensure that the `roundId` used for `move.copy(ownerRoundId = roundId)` is correct.
-                // The current structure seems to imply `roundDao.insertRound` returns the ID.
-                // Let's assume `val actualRoundId = roundDao.insertRound(actualRoundEntity)` is how it works.
-                val actualRoundId = roundDao.insertRound(actualRoundEntity)
+                // Save all accumulated rounds. Their winningCombinationJson should be set
+                // either by previous calls to resetRound() or by the logic at the start of this function.
+                _currentMatchRounds.value.forEach { roundWithMoves ->
+                    val actualRoundEntity = roundWithMoves.round.copy(ownerMatchId = matchId)
+                    // roundDao.insertRound(actualRoundEntity) // roundWithMoves.round already has winningCombinationJson
+                    // val roundId = actualRoundEntity.roundId // Assuming insertRound returns the ID or it's auto-generated and part of actualRoundEntity
+
+                    // If roundId is not directly available, this part might need adjustment
+                    // For now, assume roundId is obtainable for linking moves.
+                    // A more robust way would be to get the returned roundId from insertRound.
+                    // However, RoundEntity's PK is autoGenerate=true. The DAO insert should return the generated ID.
+                    // For simplicity, we'll assume the roundId from actualRoundEntity is sufficient if it's auto-updated post-insert,
+                    // or that the DAO structure handles this. The critical part is that actualRoundEntity has the JSON string.
+                    // The subtask should ensure that the `roundId` used for `move.copy(ownerRoundId = roundId)` is correct.
+                    // The current structure seems to imply `roundDao.insertRound` returns the ID.
+                    // Let's assume `val actualRoundId = roundDao.insertRound(actualRoundEntity)` is how it works.
+                    val actualRoundId = roundDao.insertRound(actualRoundEntity)
 
 
-                roundWithMoves.moves.forEach { move ->
-                    moveDao.insertMove(move.copy(ownerRoundId = actualRoundId))
+                    roundWithMoves.moves.forEach { move ->
+                        moveDao.insertMove(move.copy(ownerRoundId = actualRoundId))
+                    }
                 }
+            } else {
+                // Optionally, log that history saving is disabled
+                // Log.d("InfiniteTicTacToeViewModel", "Save history is disabled. Match data not saved.")
             }
 
             // Clear all match-specific states for a new game

--- a/app/src/main/java/com/a_gud_boy/tictactoe/NormalTicTacToeViewModel.kt
+++ b/app/src/main/java/com/a_gud_boy/tictactoe/NormalTicTacToeViewModel.kt
@@ -245,15 +245,20 @@ class NormalTicTacToeViewModel(
                 duration = gameTimer.getFinalMatchDuration()
             )
 
-            val matchId = matchDao.insertMatch(matchEntity)
+            if (AISettingsManager.saveHistoryEnabled) {
+                val matchId = matchDao.insertMatch(matchEntity)
 
-            _currentMatchRounds.value.forEach { roundWithMoves ->
-                val actualRoundEntity = roundWithMoves.round.copy(ownerMatchId = matchId)
-                // The roundWithMoves.round should already have winningCombinationJson populated
-                val actualRoundId = roundDao.insertRound(actualRoundEntity) // Get the actual ID
-                roundWithMoves.moves.forEach { move ->
-                    moveDao.insertMove(move.copy(ownerRoundId = actualRoundId)) // Use actual ID
+                _currentMatchRounds.value.forEach { roundWithMoves ->
+                    val actualRoundEntity = roundWithMoves.round.copy(ownerMatchId = matchId)
+                    // The roundWithMoves.round should already have winningCombinationJson populated
+                    val actualRoundId = roundDao.insertRound(actualRoundEntity) // Get the actual ID
+                    roundWithMoves.moves.forEach { move ->
+                        moveDao.insertMove(move.copy(ownerRoundId = actualRoundId)) // Use actual ID
+                    }
                 }
+            } else {
+                // Optionally, log that history saving is disabled
+                // Log.d("NormalTicTacToeViewModel", "Save history is disabled. Match data not saved.")
             }
 
             // Clear all match-specific states

--- a/app/src/test/java/com/a_gud_boy/tictactoe/AISettingsManagerTest.kt
+++ b/app/src/test/java/com/a_gud_boy/tictactoe/AISettingsManagerTest.kt
@@ -1,0 +1,141 @@
+package com.a_gud_boy.tictactoe
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Config.OLDEST_SDK]) // Configure Robolectric for a specific SDK if needed
+class AISettingsManagerTest {
+
+    private lateinit var mockContext: Context
+    private lateinit var mockSharedPreferences: SharedPreferences
+    private lateinit var mockEditor: SharedPreferences.Editor
+
+    private val PREFS_NAME = "AISettingsPrefs" // Make sure this matches the constant in AISettingsManager
+    private val KEY_SAVE_HISTORY = "key_save_history" // Make sure this matches
+
+    @Before
+    fun setUp() {
+        mockContext = ApplicationProvider.getApplicationContext<Context>()
+        mockSharedPreferences = mock(SharedPreferences::class.java)
+        mockEditor = mock(SharedPreferences.Editor::class.java)
+
+        `when`(mockContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(mockSharedPreferences)
+        `when`(mockSharedPreferences.edit()).thenReturn(mockEditor)
+        `when`(mockEditor.putBoolean(anyString(), anyBoolean())).thenReturn(mockEditor)
+        `when`(mockEditor.putString(anyString(), anyString())).thenReturn(mockEditor)
+        `when`(mockEditor.putInt(anyString(), anyInt())).thenReturn(mockEditor)
+
+        // Reset static instance for clean tests.
+        // This is a simplified approach. Ideally, AISettingsManager would be injectable or have a reset method.
+        val sharedPreferencesField = AISettingsManager::class.java.getDeclaredField("sharedPreferences")
+        sharedPreferencesField.isAccessible = true
+        sharedPreferencesField.set(AISettingsManager, null) // Force re-initialization
+
+        AISettingsManager.init(mockContext)
+    }
+
+    @After
+    fun tearDown() {
+        // Reset AISettingsManager's SharedPreferences instance to null so it can be re-initialized in the next test
+        val sharedPreferencesField = AISettingsManager::class.java.getDeclaredField("sharedPreferences")
+        sharedPreferencesField.isAccessible = true
+        sharedPreferencesField.set(AISettingsManager, null)
+    }
+
+    @Test
+    fun saveHistoryEnabled_DefaultValue_IsTrue() {
+        // Simulate that the key is not present in SharedPreferences, so it should return the default value (true)
+        `when`(mockSharedPreferences.getBoolean(KEY_SAVE_HISTORY, true)).thenReturn(true)
+
+        // Re-initialize to load settings (as if app just started and key wasn't there)
+        val sharedPreferencesField = AISettingsManager::class.java.getDeclaredField("sharedPreferences")
+        sharedPreferencesField.isAccessible = true
+        sharedPreferencesField.set(AISettingsManager, null)
+        AISettingsManager.init(mockContext)
+
+        assert(AISettingsManager.saveHistoryEnabled) { "Default value for saveHistoryEnabled should be true" }
+    }
+
+    @Test
+    fun saveHistoryEnabled_WhenSetToFalse_IsSavedAndLoadedCorrectly() {
+        AISettingsManager.saveHistoryEnabled = false
+        verify(mockEditor).putBoolean(KEY_SAVE_HISTORY, false)
+        verify(mockEditor).apply() // Verify that apply is called to save the preference
+
+        // Simulate that SharedPreferences now stores 'false' for this key
+        `when`(mockSharedPreferences.getBoolean(KEY_SAVE_HISTORY, true)).thenReturn(false)
+
+        // Re-initialize to load settings (simulating app restart)
+        val sharedPreferencesField = AISettingsManager::class.java.getDeclaredField("sharedPreferences")
+        sharedPreferencesField.isAccessible = true
+        sharedPreferencesField.set(AISettingsManager, null)
+        AISettingsManager.init(mockContext)
+
+        assert(!AISettingsManager.saveHistoryEnabled) { "saveHistoryEnabled should be false after setting and reloading" }
+    }
+
+    @Test
+    fun saveHistoryEnabled_WhenSetToTrue_IsSavedAndLoadedCorrectly() {
+        // First set it to false, then to true
+        AISettingsManager.saveHistoryEnabled = false
+        AISettingsManager.saveHistoryEnabled = true
+        verify(mockEditor).putBoolean(KEY_SAVE_HISTORY, true)
+        verify(mockEditor, times(2)).apply() // apply called for false then for true
+
+        // Simulate that SharedPreferences now stores 'true' for this key
+        `when`(mockSharedPreferences.getBoolean(KEY_SAVE_HISTORY, true)).thenReturn(true)
+
+        // Re-initialize to load settings
+        val sharedPreferencesField = AISettingsManager::class.java.getDeclaredField("sharedPreferences")
+        sharedPreferencesField.isAccessible = true
+        sharedPreferencesField.set(AISettingsManager, null)
+        AISettingsManager.init(mockContext)
+
+        assert(AISettingsManager.saveHistoryEnabled) { "saveHistoryEnabled should be true after setting and reloading" }
+    }
+
+    @Test
+    fun loadSettings_SaveHistoryNotPresent_DefaultsToTrue() {
+        `when`(mockSharedPreferences.getBoolean(KEY_SAVE_HISTORY, true)).thenReturn(true) // Default behavior of getBoolean
+
+        val sharedPreferencesField = AISettingsManager::class.java.getDeclaredField("sharedPreferences")
+        sharedPreferencesField.isAccessible = true
+        sharedPreferencesField.set(AISettingsManager, null)
+        AISettingsManager.init(mockContext)
+
+        assert(AISettingsManager.saveHistoryEnabled) { "saveHistoryEnabled should default to true if key not present" }
+    }
+
+    @Test
+    fun loadSettings_SaveHistoryPresentAsFalse_LoadsFalse() {
+        `when`(mockSharedPreferences.getBoolean(KEY_SAVE_HISTORY, true)).thenReturn(false)
+
+        val sharedPreferencesField = AISettingsManager::class.java.getDeclaredField("sharedPreferences")
+        sharedPreferencesField.isAccessible = true
+        sharedPreferencesField.set(AISettingsManager, null)
+        AISettingsManager.init(mockContext)
+
+        assert(!AISettingsManager.saveHistoryEnabled) { "saveHistoryEnabled should load as false if stored as false" }
+    }
+
+    @Test
+    fun loadSettings_SaveHistoryPresentAsTrue_LoadsTrue() {
+        `when`(mockSharedPreferences.getBoolean(KEY_SAVE_HISTORY, true)).thenReturn(true)
+
+        val sharedPreferencesField = AISettingsManager::class.java.getDeclaredField("sharedPreferences")
+        sharedPreferencesField.isAccessible = true
+        sharedPreferencesField.set(AISettingsManager, null)
+        AISettingsManager.init(mockContext)
+
+        assert(AISettingsManager.saveHistoryEnabled) { "saveHistoryEnabled should load as true if stored as true" }
+    }
+}


### PR DESCRIPTION
This commit introduces a new setting to control whether match history is saved.

Key changes:

- Added a 'saveHistoryEnabled' boolean property to AISettingsManager, persisted in SharedPreferences. Defaults to true.
- Added a 'Save History' toggle switch to the SettingsPage UI.
- Modified NormalTicTacToeViewModel and InfiniteTicTacToeViewModel to only save match data if 'saveHistoryEnabled' is true.
- Implemented a confirmation dialog in SettingsPage that appears when disabling 'Save History'.
  - If you confirm, all existing match history is deleted via HistoryViewModel.
  - If you decline, history is kept, but future matches are not saved.
- Added HistoryViewModelFactory for proper ViewModel instantiation.
- Added unit tests for AISettingsManager to verify the new setting's load/save behavior.